### PR TITLE
gemspec: Drop deprecated and unused property

### DIFF
--- a/bye-flickr.gemspec
+++ b/bye-flickr.gemspec
@@ -14,9 +14,6 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 2.0"
 
-  # required for validation
-  s.rubyforge_project         = "bye-flickr"
-
   # If you have other dependencies, add them here
   s.add_dependency "flickraw", "~> 0.9"
   s.add_dependency "net-http-persistent", "~> 3.0"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.

[Source code location with the deprecation](https://github.com/rubygems/rubygems/blob/a7e2f87e94791206d2e7bb12ff7ce75442811ce8/lib/rubygems/specification.rb#L735)